### PR TITLE
support extensionKind ui and workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "engines": {
     "vscode": "^1.6.0"
   },
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
### What

Indicate to VSCode that the extension can run in `ui` mode or in `workspace` mode.

### Why

When using VSCode with remote containers support VSCode can run extensions locally where the UI is being displayed or remotely where the files live. Many extension can run in either location, although some extension can only run on the ui side and some can only run on the workspace side.

When an extension doesn't indicate where it can be run it always runs at the workspace side.

The trailing spaces extension can run either on the UI or on the workspace and I think it should really be up to the user to choose, by default running in the ui since it works perfectly fine in the UI. The advantage of changing this and indicating it can run in both places is that when using remote dev containers the developer doesn't have to manually install the extension in the container to use it.