### PR TITLE
Dispose older decoration when creating a new one. Fixes #40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@vscode/test-electron": "^2.1.5",
                 "eslint": "^8.18.0",
                 "glob": "^8.0.3",
+                "mkdirp": "^1.0.4",
                 "mocha": "^10.0.0",
                 "ncp": "^2.0.0",
                 "typescript": "^4.7.4"
@@ -1185,6 +1186,18 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/fstream/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
         "node_modules/fstream/node_modules/rimraf": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -1617,15 +1630,15 @@
             "dev": true
         },
         "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
             "bin": {
                 "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/mocha": {
@@ -3329,6 +3342,15 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
+                "mkdirp": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+                    "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.6"
+                    }
+                },
                 "rimraf": {
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -3657,13 +3679,10 @@
             "dev": true
         },
         "mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.6"
-            }
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true
         },
         "mocha": {
             "version": "10.0.0",

--- a/src/trailing-spaces/settings.ts
+++ b/src/trailing-spaces/settings.ts
@@ -32,6 +32,8 @@ export class Settings implements TrailingSpacesSettings {
     schemesToIgnore!: { [id: string]: boolean; };
     trimOnSave!: boolean;
     showStatusBarMessage!: boolean;
+    backgroundColor!: string;
+    borderColor!: string;
     textEditorDecorationType!: vscode.TextEditorDecorationType;
 
     constructor() {
@@ -58,7 +60,7 @@ export class Settings implements TrailingSpacesSettings {
         this.schemesToIgnore = this.getMapFromStringArray(this.getOrError<string[]>(config, 'schemeIgnore'));
         this.trimOnSave = this.getOrError<boolean>(config, 'trimOnSave');
         this.showStatusBarMessage = this.getOrError<boolean>(config, 'showStatusBarMessage');
-        this.textEditorDecorationType = this.getTextEditorDecorationType(this.getOrError<string>(config, 'backgroundColor'), this.getOrError<string>(config, 'borderColor'));
+        this.setTextEditorDecorationType(config);
         this.logger.setLogLevel(this.logLevel);
         this.logger.setPrefix('Trailing Spaces');
         this.logger.log('Configuration loaded');
@@ -89,14 +91,25 @@ export class Settings implements TrailingSpacesSettings {
         return map;
     }
 
-    private getTextEditorDecorationType(backgroundColor: string, borderColor: string): vscode.TextEditorDecorationType {
-        return vscode.window.createTextEditorDecorationType({
-            borderRadius: "3px",
-            borderWidth: "1px",
-            borderStyle: "solid",
-            backgroundColor: backgroundColor,
-            borderColor: borderColor
-        });
+    private setTextEditorDecorationType(config: vscode.WorkspaceConfiguration): void {
+        let newBackgroundColor = this.getOrError<string>(config, 'backgroundColor');
+        let newBorderColor = this.getOrError<string>(config, 'borderColor');
+
+        if (newBackgroundColor !== this.backgroundColor || newBorderColor !== this.borderColor) {
+            this.backgroundColor = newBackgroundColor;
+            this.borderColor = newBorderColor;
+            if (this.textEditorDecorationType) {
+                // if an old decoration already exists, dispose it prior to creating a new one
+                this.textEditorDecorationType.dispose();
+            }
+            this.textEditorDecorationType = vscode.window.createTextEditorDecorationType({
+                borderRadius: "3px",
+                borderWidth: "1px",
+                borderStyle: "solid",
+                backgroundColor: newBackgroundColor,
+                borderColor: newBorderColor
+            });
+        }
     }
 
     private getOrError<T>(config: vscode.WorkspaceConfiguration, key: string): T {


### PR DESCRIPTION
Fixes #40 

When any user configurations are changed, we call `Settings.refreshSettings()`. During this operation, we create new instance of `TextEditorDecorationType`. However, we do not properly dispose the older decorationType, thus the older decorations are no permanently shown until the window is reloaded.

This change makes sure we dispose any existing decorationType before creating a new one. We also avoid creating a new decorationType if the decoration settings have not changed.