### PR TITLE
Replace vsmarketplacebadge.apphb.com with vsmarketplacebadges.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Trailing Spaces
 ===============
 
 [![Build Status](https://travis-ci.org/shardulm94/vscode-trailingspaces.svg?branch=master)](https://travis-ci.org/shardulm94/vscode-trailingspaces)
-[![VS Code Marketplace](https://vsmarketplacebadge.apphb.com/version-short/shardulm94.trailing-spaces.svg) ![Rating](https://vsmarketplacebadge.apphb.com/rating-short/shardulm94.trailing-spaces.svg) ![Installs](https://vsmarketplacebadge.apphb.com/installs/shardulm94.trailing-spaces.svg)](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces)
+[![VS Code Marketplace](https://vsmarketplacebadges.dev/version-short/shardulm94.trailing-spaces.svg) ![Rating](https://vsmarketplacebadges.dev/rating-short/shardulm94.trailing-spaces.svg) ![Installs](https://vsmarketplacebadges.dev/installs/shardulm94.trailing-spaces.svg)](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces)
 
 A [VS Code](https://code.visualstudio.com/) extension that allows you to…
 


### PR DESCRIPTION
See https://code.visualstudio.com/api/references/extension-manifest#approved-badges and in particular

> Note : Replace vsmarketplacebadge.apphb.com badge with vsmarketplacebadges.dev badge.

This will fix the following rendering problem in the [readme](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces):

![image](https://user-images.githubusercontent.com/115040/222974458-4a6c2cff-764b-42e4-b531-715bc475bc3a.png)

in fact trying to package the extension will also print an error, namely this error:

     ERROR  SVGs are restricted in README.md; please use other file image formats, such as PNG: https://vsmarketplacebadge.apphb.com/version-short/shardulm94.trailing-spaces.svg


# Full packaing output before and after the fix

Before fix:

```console
$ vsce --version
2.18.0
$ vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> trailing-spaces@0.4.1 vscode:prepublish
> npm run compile


> trailing-spaces@0.4.1 compile
> tsc -p ./

 ERROR  SVGs are restricted in README.md; please use other file image formats, such as PNG: https://vsmarketplacebadge.apphb.com/version-short/shardulm94.trailing-spaces.svg
```

After fix:

```console
$ vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> trailing-spaces@0.4.1 vscode:prepublish
> npm run compile


> trailing-spaces@0.4.1 compile
> tsc -p ./

 DONE  Packaged: /home/martin/src/vscode-trailingspaces/trailing-spaces-0.4.1.vsix (56 files, 7.45MB)
```
