### PR TITLE
Prepare 0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 
+## [0.4.2] - 2026-06-19
+### Fixed
+- Fixed a deprecation warning caused by the use of the deprecated `util.isNullOrUndefined` API
+
+
 ## [0.4.1] - 2022-07-10
 ### Fixed
 - Fixed an issue where changing settings would result in previously highlighted regions being permanently highlighted

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "trailing-spaces",
-    "version": "0.4.0",
+    "version": "0.4.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "trailing-spaces",
-            "version": "0.4.0",
+            "version": "0.4.2",
             "license": "MIT",
             "dependencies": {
                 "diff": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "trailing-spaces",
     "displayName": "Trailing Spaces",
     "description": "Highlight trailing spaces and delete them in a flash!",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "publisher": "shardulm94",
     "icon": "icon.png",
     "engines": {


### PR DESCRIPTION
## Summary
Prepares the 0.4.2 release.

- Bump version `0.4.1` → `0.4.2` in `package.json` (and sync `package-lock.json`, which was still pinned at `0.4.0`)
- Add `## [0.4.2]` CHANGELOG entry for the `util.isNullOrUndefined` deprecation-warning fix (#78), the only change since 0.4.1

After merge, tag `v0.4.2` and publish to the Marketplace with `vsce publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)