### PR TITLE
Fix vsce publish: replace dead SVG badges, trim package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,8 @@
 .vscode/**
 .vscode-test/**
+.keepgoing/**
+.github/**
+out/test/**
 src/**
 .gitignore
 .yarnrc

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Trailing Spaces
 ===============
 
-[![Build Status](https://travis-ci.org/shardulm94/vscode-trailingspaces.svg?branch=master)](https://travis-ci.org/shardulm94/vscode-trailingspaces)
-[![VS Code Marketplace](https://vsmarketplacebadge.apphb.com/version-short/shardulm94.trailing-spaces.svg) ![Rating](https://vsmarketplacebadge.apphb.com/rating-short/shardulm94.trailing-spaces.svg) ![Installs](https://vsmarketplacebadge.apphb.com/installs/shardulm94.trailing-spaces.svg)](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces)
+[![CI](https://img.shields.io/github/actions/workflow/status/shardulm94/vscode-trailingspaces/ci.yaml?branch=master)](https://github.com/shardulm94/vscode-trailingspaces/actions/workflows/ci.yaml)
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/shardulm94.trailing-spaces) ![Rating](https://img.shields.io/visual-studio-marketplace/r/shardulm94.trailing-spaces) ![Installs](https://img.shields.io/visual-studio-marketplace/i/shardulm94.trailing-spaces)](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces)
 
 A [VS Code](https://code.visualstudio.com/) extension that allows you to…
 


### PR DESCRIPTION
## Summary
`vsce publish` failed for 0.4.2 because vsce rejects SVG images in `README.md`, and the README's badges pointed at long-dead services.

- Replace the defunct **Travis CI** (`travis-ci.org`, shut down 2021) and **vsmarketplacebadge.apphb.com** SVG badges with working `img.shields.io` equivalents (CI via GitHub Actions, plus Marketplace version/rating/installs)
- `.vscodeignore`: exclude `.keepgoing/`, `.github/`, and `out/test/` so they're no longer bundled into the published `.vsix` (notably `.keepgoing/` contained local session state). Package drops from 69 → 41 files.

These are packaging/docs only; no extension code changed. The `v0.4.2` tag is intentionally left pointing at the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)