### PR TITLE
Credit remaining external contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,5 @@ Contributions
 - [@yustnip](https://github.com/yustnip): Added options to change background and border colors of highlighting [PR #17](https://github.com/shardulm94/vscode-trailingspaces/pull/17)
 - [@ameily](https://github.com/ameily): Properly trim spaces using the new TextEditor.edit() callback [PR #26](https://github.com/shardulm94/vscode-trailingspaces/pull/26)
 - [@mplellison](https://github.com/mplellison): Restructure tests for maintainability and ensure consecutive modified lines are trimmed [PR #44](https://github.com/shardulm94/vscode-trailingspaces/pull/44)
+- [@leighmcculloch](https://github.com/leighmcculloch): Added support for the `ui` and `workspace` extension kinds [PR #50](https://github.com/shardulm94/vscode-trailingspaces/pull/50)
+- [@dnicolson](https://github.com/dnicolson): Fixed the `util.isNullOrUndefined` deprecation warning [PR #78](https://github.com/shardulm94/vscode-trailingspaces/pull/78)


### PR DESCRIPTION
Adds the two merged external contributions that were not yet credited in the
README Contributions section:

- [@leighmcculloch](https://github.com/leighmcculloch): Support for the `ui` and `workspace` extension kinds ([#50](https://github.com/shardulm94/vscode-trailingspaces/pull/50))
- [@dnicolson](https://github.com/dnicolson): Fixed the `util.isNullOrUndefined` deprecation warning ([#78](https://github.com/shardulm94/vscode-trailingspaces/pull/78))

Found by cross-checking `git shortlog` against the existing list; these were
the only human contributors still missing. Dependabot's automated dependency
bumps are excluded, matching the existing human-contributor convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)