### PR TITLE
CI: test against VS Code Insiders, align Node 24, enforce engines.vscode floor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node-version: [20.x, 22.x]
+        # The extension runs in VS Code's bundled Electron Node, not this host
+        # Node, so a single current version is enough to build/lint/bundle.
+        node-version: [24.x]
+        # `stable` and `insiders` both ship Node 24+ and guard the new-runtime
+        # end (issue #81's class). The `engines.vscode` floor (1.68) is enforced
+        # at build time instead, via an exact `@types/vscode` pin — the modern
+        # test harness can't launch inside a VS Code that old.
+        vscode-version: [stable, insiders]
     runs-on: ${{ matrix.os }}
+    env:
+      VSCODE_VERSION: ${{ matrix.vscode-version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
             "devDependencies": {
                 "@types/diff": "^5.2.3",
                 "@types/mocha": "^10.0.10",
-                "@types/node": "^20.19.43",
-                "@types/vscode": "^1.68.0",
+                "@types/node": "^24.0.0",
+                "@types/vscode": "1.68.0",
                 "@vscode/test-electron": "^2.5.2",
                 "esbuild": "^0.28.1",
                 "eslint": "^9.39.4",
@@ -721,13 +721,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.19.43",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+            "version": "24.13.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+            "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.18.0"
             }
         },
         "node_modules/@types/vscode": {
@@ -3202,9 +3202,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
         },
@@ -3689,12 +3689,12 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.19.43",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+            "version": "24.13.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+            "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
             "dev": true,
             "requires": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.18.0"
             }
         },
         "@types/vscode": {
@@ -5303,9 +5303,9 @@
             }
         },
         "undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true
         },
         "uri-js": {

--- a/package.json
+++ b/package.json
@@ -132,8 +132,8 @@
     "devDependencies": {
         "@types/diff": "^5.2.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^20.19.43",
-        "@types/vscode": "^1.68.0",
+        "@types/node": "^24.0.0",
+        "@types/vscode": "1.68.0",
         "@vscode/test-electron": "^2.5.2",
         "esbuild": "^0.28.1",
         "eslint": "^9.39.4",

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -19,8 +19,14 @@ async function main() {
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
+        // Which VS Code build to test against. CI sets VSCODE_VERSION to run the
+        // suite on both `stable` and `insiders`; Insiders ships newer bundled
+        // Node ahead of stable, which is where runtime breakages (e.g. removed
+        // `util.*` helpers) surface first. Defaults to `stable` locally.
+        const version = process.env.VSCODE_VERSION || 'stable';
+
         // Download VS Code, unzip it and run the integration test
-        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+        await runTests({ extensionDevelopmentPath, extensionTestsPath, version });
     } catch (err) {
         console.error('Failed to run tests');
         process.exit(1);


### PR DESCRIPTION
## What

Hardens CI so the class of bug behind #81 can't ship again.

- Add a `vscode-version: [stable, insiders]` matrix dimension and run the suite against both (via a new `VSCODE_VERSION` env var consumed in `runTest.ts`).
- Collapse the host Node matrix to a single current `24.x` and bump `@types/node` to `^24`.
- Pin `@types/vscode` to exactly `1.68.0` (drop the caret) to enforce the declared `engines.vscode` floor at build time.

## Why

Issue #81 (`FAILED to handle event` / `(0,util_1.isNullOrUndefined) is not a function`) was a **runtime** breakage: VS Code 1.123 bumped its bundled Node to 24, where the long-deprecated `util.isNullOrUndefined` helper was removed. The fix already landed in #78 — but **CI never would have caught it**, for two reasons:

1. **The extension runs in VS Code's own Electron Node, not the CI host Node.** So the `node-version` matrix is irrelevant to this class of bug — only the VS Code version controls the runtime Node.
2. **The suite only ran against VS Code `stable`,** whose bundled Node still had the helper at the time. **Insiders** ships the newer Node ahead of stable — which is exactly why reporters first hit #81 on `1.122.0-insider`.

### Host Node: why a single `24.x`

VS Code **stable** has now moved to Node 24 (1.125 ships `Node.js 24.15`). The host Node only builds/lints/bundles — it never executes the extension — so testing 20.x/22.x added no consumer-facing signal. One current version that matches the shipped runtime is enough; `@types/node` is bumped to `^24` to match.

### engines.vscode floor: enforced at build time, not runtime

The `1.68.0` floor is now guarded by pinning `@types/vscode` to exactly `1.68.0`: the type-checker only knows the 1.68 API surface and rejects any newer API at compile time. A **runtime** CI job against VS Code 1.68 was tried and removed — its Node 16 lacks `diagnostics_channel.tracingChannel`, which the modern `@vscode/test-electron` harness requires, so it can't launch. The build-time type pin is the reliable, zero-cost equivalent.

## Verification

- `tsc` clean with both `@types/node@24` and the exact `@types/vscode@1.68.0` pin.
- Full suite passes locally against both `stable` and `insiders` (Node 24 runtime), including the `syntaxIgnore` / `schemeIgnore` tests that exercise the `ignoreDocument()` path which threw in v0.4.1 — i.e. this job would have caught #81.

## Note

This hardens CI; the actual fix for #81 (#78) is already on `master` and still needs a **v0.4.3 release** cut to reach users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)