### PR TITLE
Guard trim-on-save against stale edits (#80)

### DIFF
--- a/src/test/suite/issue80.test.ts
+++ b/src/test/suite/issue80.test.ts
@@ -1,0 +1,98 @@
+//
+// Regression test for issue #80:
+// https://github.com/shardulm94/vscode-trailingspaces/issues/80
+//
+// `trimOnSave` snapshots the document inside `onWillSaveTextDocument` and hands
+// the resulting ranges to VSCode through `waitUntil`. If the document changes
+// after that snapshot but before the edits are applied (the issue's "save, then
+// quickly press Delete", or another save participant such as the RedHat XML
+// formatter editing the same document), the now-stale ranges land on the wrong
+// characters and corrupt real content instead of trimming whitespace.
+//
+// The fix guards getEditsForDeletingTralingSpaces with the version the edits
+// were computed against: if the document has moved on, no edits are emitted and
+// trimming is skipped for that save. These tests pin both halves of that
+// contract - it still trims when nothing changed, and it bails out (rather than
+// corrupting) when the document changed underneath.
+//
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { before, describe, it } from 'mocha';
+import { TrailingSpaces } from '../../trailing-spaces/trailing-spaces';
+import type { TrailingSpacesApi } from '../../extension';
+
+describe("Issue #80 - trim-on-save race guard", () => {
+    before(async () => {
+        const ext = vscode.extensions.getExtension<TrailingSpacesApi>('shardulm94.trailing-spaces');
+        assert.ok(ext, "trailing-spaces extension not found in the test host");
+        await ext.activate();
+    });
+
+    // The document as it exists the instant Ctrl+S is pressed: the user has just
+    // inserted two blank lines above the <Rectangle> line (issue repro step:
+    // "insert multiple newlines above the line").
+    const snapshot = [
+        '<Lockscreen>',
+        '',                       // L1: inserted blank line
+        '',                       // L2: inserted blank line
+        'a   ',                   // L3: a line with trailing spaces -> a delete edit
+        '    <Rectangle x="0" alpha="1" fillColor="#FF000000" visibility="x" />',
+        '</Lockscreen>',
+    ].join('\n');
+
+    it("does not corrupt content when a concurrent edit shifts lines mid-save", async () => {
+        const trailingSpaces = new TrailingSpaces();
+
+        const doc = await vscode.workspace.openTextDocument({ language: 'xml', content: snapshot });
+        const editor = await vscode.window.showTextDocument(doc);
+
+        // onWillSaveTextDocument records the version it is about to compute against.
+        const versionAtSnapshot = doc.version;
+
+        // The user "quickly presses Delete", removing the two inserted blank
+        // lines before VSCode flushes the queued save edits. Every line below
+        // shifts up by two and the document version advances.
+        await editor.edit(eb => {
+            eb.delete(new vscode.Range(1, 0, 3, 0));
+        });
+        assert.notStrictEqual(doc.version, versionAtSnapshot, "expected the concurrent edit to bump the document version");
+
+        // The guarded save path now produces edits. Because the document moved
+        // on, it must emit nothing rather than stale ranges.
+        const edits = trailingSpaces.getEditsForDeletingTralingSpaces(doc, versionAtSnapshot);
+        assert.strictEqual(edits.length, 0, "stale edits must be discarded when the document changed");
+
+        const we = new vscode.WorkspaceEdit();
+        we.set(doc.uri, edits);
+        await vscode.workspace.applyEdit(we);
+
+        // Content is intact: the </Lockscreen> tag and the <Rectangle> line are untouched.
+        const after = doc.getText();
+        assert.ok(after.includes('</Lockscreen>'), `content corrupted: ${JSON.stringify(after)}`);
+        assert.ok(after.includes('alpha="1"'), `content corrupted: ${JSON.stringify(after)}`);
+
+        await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+    });
+
+    it("still trims trailing spaces when the document is unchanged at save time", async () => {
+        const trailingSpaces = new TrailingSpaces();
+
+        const doc = await vscode.workspace.openTextDocument({ language: 'xml', content: snapshot });
+        await vscode.window.showTextDocument(doc);
+
+        // No concurrent edit: the version matches, so the happy path is unaffected.
+        const edits = trailingSpaces.getEditsForDeletingTralingSpaces(doc, doc.version);
+        assert.ok(edits.length > 0, "expected trailing-space deletions on the unchanged document");
+
+        const we = new vscode.WorkspaceEdit();
+        we.set(doc.uri, edits);
+        await vscode.workspace.applyEdit(we);
+
+        const after = doc.getText().split('\n');
+        assert.strictEqual(after[3], 'a', "trailing spaces after 'a' should be trimmed");
+        assert.ok(after[5].includes('</Lockscreen>'), "content must remain intact");
+
+        await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+    });
+});

--- a/src/trailing-spaces/loader.ts
+++ b/src/trailing-spaces/loader.ts
@@ -94,7 +94,16 @@ export default class TrailingSpacesLoader {
                     this.logger.log(`onWillSaveTextDocument event called - ${event.document.fileName}`);
                     vscode.window.visibleTextEditors.forEach((editor: vscode.TextEditor) => {
                         if (event.document.uri === editor.document.uri) {
-                            event.waitUntil(Promise.resolve(this.trailingSpaces.getEditsForDeletingTralingSpaces(editor.document)));
+                            const document: vscode.TextDocument = editor.document;
+                            // Record the version we compute the edits against and
+                            // discard them if the document has moved on, so stale
+                            // ranges are never applied to shifted content (issue #80).
+                            // VSCode already ignores will-save edits on concurrent
+                            // modification; this is defense-in-depth on top of that.
+                            const versionAtSnapshot: number = document.version;
+                            event.waitUntil(Promise.resolve().then(() =>
+                                this.trailingSpaces.getEditsForDeletingTralingSpaces(document, versionAtSnapshot)
+                            ));
                         }
                     });
                 })

--- a/src/trailing-spaces/trailing-spaces.ts
+++ b/src/trailing-spaces/trailing-spaces.ts
@@ -57,10 +57,23 @@ export class TrailingSpaces {
     /**
      * Returns the edits required to delete the trailings spaces from a document
      *
+     * The returned edits are position ranges computed against the document as it
+     * is at call time. If the caller intends to apply them later (e.g. as a save
+     * participant via onWillSaveTextDocument), it must pass `expectedVersion` so
+     * we can detect a concurrent change. Applying stale ranges to a document that
+     * has moved on lands them on the wrong characters and corrupts content - see
+     * issue #80. When the document version no longer matches, no edits are
+     * returned and trimming is simply skipped for this pass.
+     *
      * @param {vscode.TextDocument} document The document in which the trailing spaces should be found
+     * @param {number} expectedVersion The document version the edits must apply against; if the live version differs, no edits are returned
      * @returns {vscode.TextEdit[]} An array of edits required to delete the trailings spaces from the document
      */
-    public getEditsForDeletingTralingSpaces(document: vscode.TextDocument): vscode.TextEdit[] {
+    public getEditsForDeletingTralingSpaces(document: vscode.TextDocument, expectedVersion?: number): vscode.TextEdit[] {
+        if (expectedVersion !== undefined && document.version !== expectedVersion) {
+            this.logger.warn(`Document changed during save; skipping trailing space deletion to avoid corrupting content - ${document.fileName}`);
+            return [];
+        }
         let ranges: vscode.Range[] = this.getRangesToDelete(document);
         let edits: vscode.TextEdit[] = new Array<vscode.TextEdit>(ranges.length);
         for (let i: number = ranges.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Problem

Fixes #80 — rare XML content corruption when `trimOnSave` is used alongside the RedHat XML formatter.

`trimOnSave` snapshots the document inside `onWillSaveTextDocument` and hands the resulting **position ranges** to `waitUntil`. If the document changes after that snapshot but before the edits are applied — a concurrent keystroke during save (the issue's "save, then quickly press Delete"), or another save participant such as the XML formatter editing the same document — the now-stale ranges land on the wrong characters and **delete real content** instead of trailing whitespace. That produces the corruption in the report (`a lpha`, the stray `<` on its own line).

I reproduced the mechanism deterministically through the extension's real save-path method: a stale trim edit applied after a concurrent line-shifting edit turned `</Lockscreen>` into `<ckscreen>`.

## Fix

Guard `getEditsForDeletingTralingSpaces` with the document version the edits were computed against. If the live `document.version` differs, emit **no edits** and skip trimming for that save (it trims on the next clean save) rather than applying stale ranges to shifted content. The happy path — trimming an unchanged document — is unaffected.

### Scope / expectations

This is **defense-in-depth**, not a hermetic fix. VSCode's `waitUntil` contract already states will-save edits are *"ignored if concurrent modifications of the document happened"*, so the platform owns the primary guarantee; the residual #80 corruption stems from how two save participants' edits compose, which VSCode mediates. This change ensures the extension never contributes stale ranges and documents the failure mode, but a fully robust fix isn't achievable from the extension side alone.

`document.version` is a non-optional `number` on every `TextDocument` (including untitled/unsaved), strictly increasing — so the guard is safe across schemes, untitled docs, and closed-editor edge cases.

## Tests

Adds `issue80.test.ts` with two regression tests (both on an untitled doc): content stays intact when a concurrent edit shifts lines mid-save, and trimming still works when the document is unchanged. All 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)