### PR TITLE
Fix trimOnSave when the saving document's editor is hidden (#76)

### DIFF
--- a/src/test/suite/issue76.test.ts
+++ b/src/test/suite/issue76.test.ts
@@ -1,0 +1,62 @@
+// Repro for https://github.com/shardulm94/vscode-trailingspaces/issues/76
+//
+// trimOnSave fails when files.autoSave=onFocusChange and focus moves to
+// another tab in the SAME window. The save fires for a document whose editor
+// is no longer in window.visibleTextEditors, so loader's onWillSave handler
+// (which only edits editors found in visibleTextEditors) applies no edits.
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { before, after, describe, it } from 'mocha';
+import type { Settings } from '../../trailing-spaces/settings';
+import type { TrailingSpacesApi } from '../../extension';
+
+describe("Issue 76 - trimOnSave with hidden editor", () => {
+    let settings: Settings;
+    let fileA: string;
+    let fileB: string;
+
+    before(async () => {
+        const ext = vscode.extensions.getExtension<TrailingSpacesApi>('shardulm94.trailing-spaces');
+        assert.ok(ext, "trailing-spaces extension not found in the test host");
+        settings = (await ext.activate()).settings;
+        // Enable trimOnSave; the config change reinitializes the listeners.
+        await vscode.workspace.getConfiguration('trailing-spaces').update('trimOnSave', true, true);
+
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-issue76-'));
+        fileA = path.join(dir, 'a.txt');
+        fileB = path.join(dir, 'b.txt');
+        fs.writeFileSync(fileA, 'hello\n');
+        fs.writeFileSync(fileB, 'world\n');
+    });
+
+    it("trims trailing spaces even when the document's editor is hidden", async () => {
+        const docA = await vscode.workspace.openTextDocument(vscode.Uri.file(fileA));
+        const editorA = await vscode.window.showTextDocument(docA, vscode.ViewColumn.One);
+
+        // Add trailing spaces to A.
+        await editorA.edit(eb => eb.insert(new vscode.Position(0, 5), '   '));
+        assert.ok(docA.getText().includes('hello   '), "precondition: A has trailing spaces");
+
+        // Switch to B in the SAME column -> A's editor leaves visibleTextEditors.
+        const docB = await vscode.workspace.openTextDocument(vscode.Uri.file(fileB));
+        await vscode.window.showTextDocument(docB, vscode.ViewColumn.One);
+        assert.ok(
+            !vscode.window.visibleTextEditors.some(e => e.document.uri.toString() === docA.uri.toString()),
+            "precondition: A's editor is hidden"
+        );
+
+        // Save A (what autoSave=onFocusChange does behind the scenes).
+        await docA.save();
+
+        assert.strictEqual(docA.getText(), 'hello\n', "trailing spaces should be trimmed on save");
+    });
+
+    after(async () => {
+        await settings.resetToDefaults();
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    });
+});

--- a/src/trailing-spaces/loader.ts
+++ b/src/trailing-spaces/loader.ts
@@ -92,20 +92,16 @@ export default class TrailingSpacesLoader {
             disposables.push(
                 vscode.workspace.onWillSaveTextDocument((event: vscode.TextDocumentWillSaveEvent) => {
                     this.logger.log(`onWillSaveTextDocument event called - ${event.document.fileName}`);
-                    vscode.window.visibleTextEditors.forEach((editor: vscode.TextEditor) => {
-                        if (event.document.uri === editor.document.uri) {
-                            const document: vscode.TextDocument = editor.document;
-                            // Record the version we compute the edits against and
-                            // discard them if the document has moved on, so stale
-                            // ranges are never applied to shifted content (issue #80).
-                            // VSCode already ignores will-save edits on concurrent
-                            // modification; this is defense-in-depth on top of that.
-                            const versionAtSnapshot: number = document.version;
-                            event.waitUntil(Promise.resolve().then(() =>
-                                this.trailingSpaces.getEditsForDeletingTralingSpaces(document, versionAtSnapshot)
-                            ));
-                        }
-                    });
+                    const document: vscode.TextDocument = event.document;
+                    // Record the version we compute the edits against and discard
+                    // them if the document has moved on, so stale ranges are never
+                    // applied to shifted content (issue #80). VSCode already ignores
+                    // will-save edits on concurrent modification; this is
+                    // defense-in-depth on top of that.
+                    const versionAtSnapshot: number = document.version;
+                    event.waitUntil(Promise.resolve().then(() =>
+                        this.trailingSpaces.getEditsForDeletingTralingSpaces(document, versionAtSnapshot)
+                    ));
                 })
             );
         }


### PR DESCRIPTION
## Summary

Fixes #76. With `trailing-spaces.trimOnSave: true` and `files.autoSave: onFocusChange`, switching to another **tab in the same window** saved the file but left trailing spaces in place. Switching to another window/app worked fine.

## Root cause

The `onWillSaveTextDocument` handler looped over `window.visibleTextEditors` and only trimmed when the saving document matched a *visible* editor:

```ts
vscode.window.visibleTextEditors.forEach((editor) => {
    if (event.document.uri === editor.document.uri) { ... }
});
```

When you switch tabs in the same editor group, the saved document's editor is no longer visible, so the loop matches nothing and no edits are applied. Switching to a different window keeps the tab active/visible, which is why that path worked — exactly the asymmetry in the report.

The `visibleTextEditors` match was **vestigial**: it existed to recover the editor's `selection` for the old selection-aware delete path, which has not been used since the 2019 refactor (`getEditsForDeletingTralingSpaces` now operates purely on a `TextDocument`). So we use `event.document` directly.

The #80 version-snapshot race guard is preserved.

## Test

Adds a regression test (src/test/suite/issue76.test.ts) that adds trailing spaces, hides the editor behind another tab in the same view column, saves, and asserts the spaces are trimmed. Fails before the fix, passes after. Full suite: 13 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)