### PR TITLE
Prepare 0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
 
+## [0.4.3] - 2026-06-19
+### Fixed
+- Fixed `trimOnSave` not trimming when the saved document's editor is hidden, e.g. with `files.autoSave: onFocusChange` (#76)
+- Guarded `trimOnSave` against stale edits so a concurrent edit or another save participant can no longer cause real content to be corrupted (#80)
+### Changed
+- Modernized the build: the extension is now bundled with esbuild, dependencies were refreshed, and the test suite and CI were updated
+
+
 ## [0.4.2] - 2026-06-19
 ### Fixed
 - Fixed a deprecation warning caused by the use of the deprecated `util.isNullOrUndefined` API

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "trailing-spaces",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "trailing-spaces",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "license": "MIT",
             "dependencies": {
                 "diff": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "trailing-spaces",
     "displayName": "Trailing Spaces",
     "description": "Highlight trailing spaces and delete them in a flash!",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "publisher": "shardulm94",
     "icon": "icon.png",
     "engines": {


### PR DESCRIPTION
Bumps the extension to **0.4.3** and updates the changelog for everything shipped since 0.4.2.

## Changelog
### Fixed
- `trimOnSave` not trimming when the saved document's editor is hidden, e.g. with `files.autoSave: onFocusChange` (#76, #91)
- Guarded `trimOnSave` against stale edits so a concurrent edit or another save participant can no longer corrupt real content (#80, #90)

### Changed
- Modernized the build: bundled with esbuild, refreshed dependencies, updated the test suite and CI (#87, #88, #89, #92)

## Release files
- `package.json` / `package-lock.json` → 0.4.3
- `CHANGELOG.md` → 0.4.3 section

Verified locally: `npm run package` (type-check + lint + production build) passes and `vsce package` produces a clean `trailing-spaces-0.4.3.vsix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)