### PR TITLE
Fix split-view highlight desync (#71)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,16 +4,29 @@ import * as vscode from 'vscode';
 import TrailingSpacesLoader from './trailing-spaces/loader';
 import { Settings } from './trailing-spaces/settings';
 
-export interface TrailingSpacesApi {
+/**
+ * Test-only hooks. The extension returns these only when running outside
+ * production (i.e. in the integration-test host); real users get `undefined`,
+ * so internal objects are never handed out on the production API surface.
+ */
+export interface TrailingSpacesTestApi {
+    // The same Settings singleton the extension actually uses. The published
+    // extension is bundled, so a test importing the Settings module directly
+    // would get a *different* instance than the one running inside the host.
     settings: Settings;
+    // Decorations cannot be read back through the VSCode API, so this surfaces
+    // the ranges most recently highlighted in a given editor for assertions.
+    getHighlightedRanges(editor: vscode.TextEditor): readonly vscode.Range[];
 }
 
-export function activate(context: vscode.ExtensionContext): TrailingSpacesApi {
+export function activate(context: vscode.ExtensionContext): TrailingSpacesTestApi | undefined {
     let trailingSpacesLoader: TrailingSpacesLoader = new TrailingSpacesLoader();
     trailingSpacesLoader.activate(context.subscriptions);
-    // Exposed so integration tests can drive the same Settings singleton the
-    // extension actually uses. The published extension is bundled, so a test
-    // importing the Settings module directly would get a *different* instance
-    // than the one running inside the extension host.
-    return { settings: Settings.getInstance() };
+    if (context.extensionMode === vscode.ExtensionMode.Production) {
+        return undefined;
+    }
+    return {
+        settings: Settings.getInstance(),
+        getHighlightedRanges: (editor: vscode.TextEditor) => trailingSpacesLoader.getHighlightedRanges(editor)
+    };
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -10,7 +10,7 @@ import * as assert from 'assert';
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 import type { Settings } from '../../trailing-spaces/settings';
-import type { TrailingSpacesApi } from '../../extension';
+import type { TrailingSpacesTestApi } from '../../extension';
 import * as path from 'path';
 import { Done, afterEach, before, describe, it } from 'mocha';
 import * as fs from 'fs';
@@ -21,9 +21,11 @@ describe("Extension Tests", () => {
     before(async () => {
         // Drive the same Settings singleton the (bundled) extension uses,
         // rather than importing the module directly — see activate()'s return.
-        const ext = vscode.extensions.getExtension<TrailingSpacesApi>('shardulm94.trailing-spaces');
+        const ext = vscode.extensions.getExtension<TrailingSpacesTestApi | undefined>('shardulm94.trailing-spaces');
         assert.ok(ext, "trailing-spaces extension not found in the test host");
-        settings = (await ext.activate()).settings;
+        const api = await ext.activate();
+        assert.ok(api, "test API should be available outside production");
+        settings = api.settings;
     });
 
     async function loadTestFileIntoEditor(testFileName: string, done: Done): Promise<vscode.TextEditor> {

--- a/src/test/suite/issue71-highlight.test.ts
+++ b/src/test/suite/issue71-highlight.test.ts
@@ -1,0 +1,88 @@
+// Repro for the split-view highlight desync described in
+// https://github.com/shardulm94/vscode-trailingspaces/issues/71
+//
+// When the SAME document is open in two split panes, editing one pane only
+// re-highlights the *active* editor. The other pane showing the same document
+// keeps stale decorations:
+//   - add a space in the right pane     -> left pane does not show the highlight
+//   - delete the space in the left pane -> right pane keeps a stale red sliver
+//
+// Decorations are not readable through the VSCode API, so we observe the ranges
+// the extension applies to each editor via TrailingSpaces.highlightedRanges.
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { before, after, describe, it } from 'mocha';
+import type { Settings } from '../../trailing-spaces/settings';
+import type { TrailingSpacesTestApi } from '../../extension';
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+    const start = Date.now();
+    while (!predicate()) {
+        if (Date.now() - start > timeoutMs) {
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+}
+
+describe("Issue 71 - split-view highlight desync", () => {
+    let settings: Settings;
+    let testApi: TrailingSpacesTestApi;
+    let file: string;
+
+    before(async () => {
+        const ext = vscode.extensions.getExtension<TrailingSpacesTestApi | undefined>('shardulm94.trailing-spaces');
+        assert.ok(ext, "trailing-spaces extension not found in the test host");
+        const api = await ext.activate();
+        assert.ok(api, "test API should be available outside production");
+        testApi = api;
+        settings = api.settings;
+
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-issue71-hl-'));
+        file = path.join(dir, 'a.txt');
+        fs.writeFileSync(file, 'hello\n');
+    });
+
+    it("keeps highlights in sync across split panes of the same document", async () => {
+        const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(file));
+
+        const left = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        const right = await vscode.window.showTextDocument(doc, vscode.ViewColumn.Two);
+
+        const leftRanges = () => testApi.getHighlightedRanges(left);
+        const rightRanges = () => testApi.getHighlightedRanges(right);
+
+        // Step 1+2: right pane is active; introduce a trailing space there.
+        await right.edit(eb => eb.insert(new vscode.Position(0, 5), '   '));
+        await waitFor(() => leftRanges().length > 0);
+
+        assert.strictEqual(
+            rightRanges().length, 1,
+            "active (right) pane should highlight the new trailing space");
+        assert.strictEqual(
+            leftRanges().length, 1,
+            "left pane should also highlight the trailing space added in the right pane");
+
+        // Step 3+4: focus the left pane and remove the trailing space there.
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await left.edit(eb => eb.delete(new vscode.Range(0, 5, 0, 8)));
+        await waitFor(() => rightRanges().length === 0);
+
+        assert.strictEqual(doc.getText(), 'hello\n', "precondition: trailing space removed");
+        assert.strictEqual(
+            leftRanges().length, 0,
+            "active (left) pane should clear its highlight");
+        assert.strictEqual(
+            rightRanges().length, 0,
+            "right pane should also clear its highlight (no stale red sliver)");
+    });
+
+    after(async () => {
+        await settings.resetToDefaults();
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    });
+});

--- a/src/test/suite/issue71.test.ts
+++ b/src/test/suite/issue71.test.ts
@@ -1,0 +1,52 @@
+// Repro for https://github.com/shardulm94/vscode-trailingspaces/issues/71
+//
+// When the SAME file is opened more than once in split view, trimOnSave stops
+// working: the trailing space survives the save in both panes.
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { before, after, describe, it } from 'mocha';
+import type { Settings } from '../../trailing-spaces/settings';
+import type { TrailingSpacesTestApi } from '../../extension';
+
+describe("Issue 71 - trimOnSave with same file in split view", () => {
+    let settings: Settings;
+    let fileA: string;
+
+    before(async () => {
+        const ext = vscode.extensions.getExtension<TrailingSpacesTestApi | undefined>('shardulm94.trailing-spaces');
+        assert.ok(ext, "trailing-spaces extension not found in the test host");
+        const api = await ext.activate();
+        assert.ok(api, "test API should be available outside production");
+        settings = api.settings;
+        await vscode.workspace.getConfiguration('trailing-spaces').update('trimOnSave', true, true);
+
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-issue71-'));
+        fileA = path.join(dir, 'a.txt');
+        fs.writeFileSync(fileA, 'hello\n');
+    });
+
+    it("trims trailing spaces when the same file is open in two split panes", async () => {
+        const docA = await vscode.workspace.openTextDocument(vscode.Uri.file(fileA));
+
+        // Open the same document in two columns (split view).
+        const editorOne = await vscode.window.showTextDocument(docA, vscode.ViewColumn.One);
+        await vscode.window.showTextDocument(docA, vscode.ViewColumn.Two);
+
+        // Introduce a trailing space.
+        await editorOne.edit(eb => eb.insert(new vscode.Position(0, 5), '   '));
+        assert.ok(docA.getText().includes('hello   '), "precondition: doc has trailing spaces");
+
+        await docA.save();
+
+        assert.strictEqual(docA.getText(), 'hello\n', "trailing spaces should be trimmed on save");
+    });
+
+    after(async () => {
+        await settings.resetToDefaults();
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    });
+});

--- a/src/test/suite/issue76.test.ts
+++ b/src/test/suite/issue76.test.ts
@@ -12,7 +12,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import { before, after, describe, it } from 'mocha';
 import type { Settings } from '../../trailing-spaces/settings';
-import type { TrailingSpacesApi } from '../../extension';
+import type { TrailingSpacesTestApi } from '../../extension';
 
 describe("Issue 76 - trimOnSave with hidden editor", () => {
     let settings: Settings;
@@ -20,9 +20,11 @@ describe("Issue 76 - trimOnSave with hidden editor", () => {
     let fileB: string;
 
     before(async () => {
-        const ext = vscode.extensions.getExtension<TrailingSpacesApi>('shardulm94.trailing-spaces');
+        const ext = vscode.extensions.getExtension<TrailingSpacesTestApi | undefined>('shardulm94.trailing-spaces');
         assert.ok(ext, "trailing-spaces extension not found in the test host");
-        settings = (await ext.activate()).settings;
+        const api = await ext.activate();
+        assert.ok(api, "test API should be available outside production");
+        settings = api.settings;
         // Enable trimOnSave; the config change reinitializes the listeners.
         await vscode.workspace.getConfiguration('trailing-spaces').update('trimOnSave', true, true);
 

--- a/src/test/suite/issue80.test.ts
+++ b/src/test/suite/issue80.test.ts
@@ -20,11 +20,11 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { before, describe, it } from 'mocha';
 import { TrailingSpaces } from '../../trailing-spaces/trailing-spaces';
-import type { TrailingSpacesApi } from '../../extension';
+import type { TrailingSpacesTestApi } from '../../extension';
 
 describe("Issue #80 - trim-on-save race guard", () => {
     before(async () => {
-        const ext = vscode.extensions.getExtension<TrailingSpacesApi>('shardulm94.trailing-spaces');
+        const ext = vscode.extensions.getExtension<TrailingSpacesTestApi | undefined>('shardulm94.trailing-spaces');
         assert.ok(ext, "trailing-spaces extension not found in the test host");
         await ext.activate();
     });

--- a/src/trailing-spaces/loader.ts
+++ b/src/trailing-spaces/loader.ts
@@ -18,6 +18,10 @@ export default class TrailingSpacesLoader {
         this.trailingSpaces = new TrailingSpaces();
     }
 
+    public getHighlightedRanges(editor: vscode.TextEditor): readonly vscode.Range[] {
+        return this.trailingSpaces.getHighlightedRanges(editor);
+    }
+
     public activate(subscriptions: vscode.Disposable[]): void {
         subscriptions.push(this);
         this.initialize(subscriptions);
@@ -64,16 +68,16 @@ export default class TrailingSpacesLoader {
                     }
                 }),
                 vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
-                    if (vscode.window.activeTextEditor !== undefined && vscode.window.activeTextEditor.document === event.document) {
-                        this.logger.log(`onDidChangeTextDocument event called - ${event.document.fileName}`);
-                        this.trailingSpaces.highlight(vscode.window.activeTextEditor);
-                    }
+                    this.logger.log(`onDidChangeTextDocument event called - ${event.document.fileName}`);
+                    // Re-highlight every visible editor showing this document, not
+                    // just the active one. When the same file is open in split view,
+                    // editing one pane must refresh the other pane's decorations too,
+                    // otherwise highlights desync between panes (issue #71).
+                    this.highlightEditorsForDocument(event.document);
                 }),
                 vscode.workspace.onDidOpenTextDocument((document: vscode.TextDocument) => {
-                    if (vscode.window.activeTextEditor !== undefined && vscode.window.activeTextEditor.document === document) {
-                        this.logger.log(`onDidOpenTextDocument event called - ${document.fileName}`);
-                        this.trailingSpaces.highlight(vscode.window.activeTextEditor);
-                    }
+                    this.logger.log(`onDidOpenTextDocument event called - ${document.fileName}`);
+                    this.highlightEditorsForDocument(document);
                 })
             );
 
@@ -106,6 +110,12 @@ export default class TrailingSpacesLoader {
             );
         }
         this.listenerDisposables = disposables;
+    }
+
+    private highlightEditorsForDocument(document: vscode.TextDocument): void {
+        vscode.window.visibleTextEditors
+            .filter((editor: vscode.TextEditor) => editor.document === document)
+            .forEach((editor: vscode.TextEditor) => this.trailingSpaces.highlight(editor));
     }
 
     private highlightActiveEditors(): void {

--- a/src/trailing-spaces/trailing-spaces.ts
+++ b/src/trailing-spaces/trailing-spaces.ts
@@ -11,9 +11,26 @@ export class TrailingSpaces {
     private logger: ILogger;
     private settings: TrailingSpacesSettings;
 
+    /**
+     * The ranges most recently applied to each editor as decorations. Decorations
+     * are not readable back through the VSCode API, so we retain them to let tests
+     * assert what is highlighted (e.g. that split-view panes stay in sync). Keyed
+     * weakly so closed editors are collected.
+     */
+    private readonly highlightedRanges: WeakMap<vscode.TextEditor, readonly vscode.Range[]> = new WeakMap();
+
     constructor() {
         this.logger = Logger.getInstance();
         this.settings = Settings.getInstance();
+    }
+
+    /**
+     * Returns the ranges most recently highlighted in the given editor. Intended
+     * for test observation only, since decorations cannot be read back from the
+     * VSCode API.
+     */
+    public getHighlightedRanges(editor: vscode.TextEditor): readonly vscode.Range[] {
+        return this.highlightedRanges.get(editor) ?? [];
     }
 
     public highlight(editor: vscode.TextEditor, editorEdit: vscode.TextEditorEdit | undefined = undefined): void {
@@ -35,7 +52,9 @@ export class TrailingSpaces {
      * @param {vscode.TextEditor} editor The editor in which the spaces have to be highlighted
      */
     private highlightTrailingSpaces(editor: vscode.TextEditor): void {
-        editor.setDecorations(this.settings.textEditorDecorationType, this.getRangesToHighlight(editor.document, editor.selections));
+        let ranges: vscode.Range[] = this.getRangesToHighlight(editor.document, editor.selections);
+        editor.setDecorations(this.settings.textEditorDecorationType, ranges);
+        this.highlightedRanges.set(editor, ranges);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes the highlight half of #71. When the **same file is open in multiple split panes**, editing one pane only re-highlighted the *active* editor, leaving the other pane's trailing-space decorations stale:

- Add a space in the right pane → left pane never showed the highlight.
- Delete the space in the left pane → right pane kept a leftover red sliver.

Root cause: `onDidChangeTextDocument` only called `highlight()` on `window.activeTextEditor`. Decorations are per-`TextEditor`, so the other visible editor for the same document was never refreshed. The fix re-highlights **every visible editor showing the changed document**.

> Note: the *other* half of #71 (trim-on-save not firing in split view) was already fixed by the #76 refactor. This PR adds a regression test for that path too, but the behavioral fix here is for the highlight desync.

## Tests

Two new split-view regression tests (`issue71.test.ts`, `issue71-highlight.test.ts`), both verified to fail without the corresponding fix and pass with it. Full suite: 15 passing.

Decorations can't be read back through the VS Code API, so `TrailingSpaces` retains the ranges it applies per editor (`WeakMap`) and exposes a narrow `getHighlightedRanges` fetcher. The integration-test hooks (`settings` + `getHighlightedRanges`) are returned from `activate()` **only outside production** (gated on `extensionMode`), so no internal objects are exposed on the production API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)