### PR TITLE
Prepare 0.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 
+## [0.4.4] - 2026-06-22
+### Fixed
+- Fixed trailing-space highlights desyncing between split panes showing the same file: editing in one pane now refreshes the decorations in every visible pane, so highlights no longer go missing or leave a stale sliver behind (#71)
+
+
 ## [0.4.3] - 2026-06-19
 ### Fixed
 - Fixed `trimOnSave` not trimming when the saved document's editor is hidden, e.g. with `files.autoSave: onFocusChange` (#76)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "trailing-spaces",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "trailing-spaces",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "license": "MIT",
             "dependencies": {
                 "diff": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "trailing-spaces",
     "displayName": "Trailing Spaces",
     "description": "Highlight trailing spaces and delete them in a flash!",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "publisher": "shardulm94",
     "icon": "icon.png",
     "engines": {


### PR DESCRIPTION
Bumps the version to **0.4.4** and adds a CHANGELOG entry for the split-view highlight desync fix (#71) merged since 0.4.3.

### Changes
- `package.json` / `package-lock.json`: `0.4.3` → `0.4.4`
- `CHANGELOG.md`: new `## [0.4.4]` section

### Included since 0.4.3
- Fixed trailing-space highlights desyncing between split panes showing the same file (#71, merged in #94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)